### PR TITLE
rpi3: remove jtag enable code

### DIFF
--- a/board/raspberrypi/rpi/rpi.c
+++ b/board/raspberrypi/rpi/rpi.c
@@ -376,41 +376,12 @@ static void set_serial_number(void)
 
 int misc_init_r(void)
 {
-# ifdef CONFIG_JTAG_ENABLE
-# define GPFSEL0     0x3F200000
-# define GPFSEL1     (GPFSEL0+4)
-# define GPFSEL2     (GPFSEL0+8)
-# endif
-
-# ifdef CONFIG_JTAG_ENABLE
-	uint32_t val;
-	uint32_t *reg;
-# endif
-
-
 	set_fdtfile();
 	set_usbethaddr();
 #ifdef CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG
 	set_board_info();
 #endif
 	set_serial_number();
-
-# ifdef CONFIG_JTAG_ENABLE
-	/* gpio4, alt5 ARM_TDI */
-	reg = (uint32_t *)(GPFSEL0);
-	val = *reg;
-	val = val & ~(7 << 12);
-	val = val | (2 << 12);
-	*reg = val;
-
-	reg = (uint32_t *)(GPFSEL2);
-	val = *reg;
-	val = val & ~((7 << 6) | (7 << 12) | (7 << 15) | (7 << 21));
-	/*           TRST      RTCK       TDO         TCK         TMS */
-	val = val | (3 << 6) | (3 << 9) | (3 << 12) | (3 << 15) | (3 << 21);
-	*reg = val;
-	printf("JTAG (gpio) enabled\n");
-# endif
 
 	return 0;
 }

--- a/common/board_f.c
+++ b/common/board_f.c
@@ -740,18 +740,10 @@ static int setup_reloc(void)
 #endif
 	memcpy(gd->new_gd, (char *)gd, sizeof(gd_t));
 
-# ifndef CONFIG_JTAG_ENABLE
 	debug("Relocation Offset is: %08lx\n", gd->reloc_off);
 	debug("Relocating to %08lx, new gd at %08lx, sp at %08lx\n",
 	       gd->relocaddr, (ulong)map_to_sysmem(gd->new_gd),
 	       gd->start_addr_sp);
-# else
-	printf("Relocation Offset is: %08lx\n", gd->reloc_off);
-	printf("Relocating to %08lx, new gd at %08lx, sp at %08lx\n",
-	       gd->relocaddr, (ulong)map_to_sysmem(gd->new_gd),
-	       gd->start_addr_sp);
-	printf("gdb symbol-file offset is: %08lx\n", gd->relocaddr);
-# endif
 
 	return 0;
 }

--- a/include/configs/rpi.h
+++ b/include/configs/rpi.h
@@ -24,7 +24,6 @@
 #define CONFIG_SYS_CACHELINE_SIZE		64
 #endif
 
-# define CONFIG_JTAG_ENABLE
 # define CONFIG_CMD_BOOTZ	/* boot zImage			*/
 
 /* Architecture, CPU, etc.*/


### PR DESCRIPTION
Remove JTAG enable switches for Rpi3. The Raspberry Pi 3 allows to
enable JTAG on the GPIO via the enable_jtag_gpio=1 flag in the
config.txt, which is more prefarable.

Fixes: https://github.com/OP-TEE/optee_os/issues/1634
Deprecates: https://github.com/linaro-swg/u-boot/pull/1

```
Suggested-by: Joseph Pantoga <jp@redballoonsecurity.com>
Signed-off-by: Igor Opaniuk <igor.opaniuk@linaro.org>
Tested-by: Igor Opaniuk <igor.opaniuk@linaro.org> (RPi3)
```